### PR TITLE
Fix UDP packet configuration

### DIFF
--- a/pack-scan.py
+++ b/pack-scan.py
@@ -19,9 +19,9 @@ import threading
 import time
 
 ####################### MUST BE CONFIGURED ##########################
-SERVER_PORT = 7778 #Assuming your samp server runs on this port
-PROXY_PORT = 7779 #Assuming no other servers are running on this one, as it will be taken by the code.
-SAMP_SERVER_ADDRESS = "54.38.10.194" #Public ip
+SERVER_PORT = 7777 #Assuming your samp server runs on this port
+PROXY_PORT = 7778 #Assuming no other servers are running on this one, as it will be taken by the code.
+SAMP_SERVER_ADDRESS = "INSERT SERVER IP HERE" #Public ip
 #####################################################################
 
 SAMP_SERVER_LOCALHOST = "127.0.0.1" #Edit this if you run this on a different server than the samp server


### PR DESCRIPTION
- Certain assemblies such as the 'p' opcode did not function correctly and never caught the attention of the samp server. Hence, the error would always write: can't connect to samp server
- Packet payloads were transformed into bytes after being assembled and this caused errors. Instead, the packets are now assembled for every part using byte format.
- If you had a BIND address (for instance a fallback IP) the proxy would send back the packet using the eth0 / main interface. The BIND is now the same as the samp server public IP.
Tested and in use at www.xsfserver.com, currently being spammed with packets.